### PR TITLE
GHA: Install lxml compilation dependencies.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2
+    - name: Install lxml compilation dependencies
+      run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-dev libxslt1-dev
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Should fix [failing action on Plone 5.0](https://github.com/plone/Products.PloneHotfix20210518/actions/runs/961907318). 5.2 already passed though, probably a wheel is available.
