### PR TITLE
Disallow access to string.Formatter (and Template).

### DIFF
--- a/Products/PloneHotfix20210518/CHANGES.rst
+++ b/Products/PloneHotfix20210518/CHANGES.rst
@@ -5,7 +5,12 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix Remote Code Execution via Python Script and string Formatter.
+  This is a variant of earlier vulnerabilities in this hotfix.
+  Only Plone 5.2 on Python 3 is vulnerable.
+  Alternatively on Python 5.2, you can upgrade to ``AccessControl`` 4.3.
+  On earlier versions of Plone and Python, the fix is not needed,
+  but it is fine to upgrade to this new hotfix version.
 
 
 1.5 (2021-06-28)

--- a/Products/PloneHotfix20210518/README.txt
+++ b/Products/PloneHotfix20210518/README.txt
@@ -30,6 +30,10 @@ This hotfix fixes several security issues:
 - XSS in folder contents on Plone 5.0 and higher.
   Reported by Matt Moreschi.
   Only included since version 1.5 of the hotfix.
+- Remote Code Execution via Python Script.
+  Reported by Calum Hutton.
+  Only Plone 5.2 on Python 3 is vulnerable.
+  Only included since version 1.6 of the hotfix.
 
 
 Compatibility
@@ -75,6 +79,8 @@ These vulnerabilities mentioned above are relevant for Zope:
   Fixes released in Products.CMFCore 2.5.1 and Products.PluggableAuthService 2.6.2.
 - Remote Code Execution via traversal in expressions via string formatter.
   Fixes released in Zope 4.6.2, which takes over the already stricter code from Zope 5.2.1.
+- Remote Code Execution via Python Script.
+  Fixes released in Zope 4.6.3 and 5.3.
 
 
 Installation

--- a/Products/PloneHotfix20210518/__init__.py
+++ b/Products/PloneHotfix20210518/__init__.py
@@ -26,6 +26,7 @@ else:
 # General hotfixes for all, including Zope/CMF.
 hotfixes = [
     "expressions",
+    "formatter",
     "genericsetup",
     "pas",
     "propertymanager",

--- a/Products/PloneHotfix20210518/formatter.py
+++ b/Products/PloneHotfix20210518/formatter.py
@@ -1,0 +1,8 @@
+from AccessControl import ModuleSecurityInfo
+from AccessControl import secureModule
+
+
+string_modsec = ModuleSecurityInfo("string")
+for name in ("Formatter", "Template"):
+    string_modsec.declarePrivate(name)  # NOQA: D001
+secureModule("string")

--- a/Products/PloneHotfix20210518/tests/test_formatter.py
+++ b/Products/PloneHotfix20210518/tests/test_formatter.py
@@ -1,0 +1,32 @@
+from Products.PythonScripts.PythonScript import PythonScript
+from Testing.makerequest import makerequest
+from zExceptions import Unauthorized
+
+import unittest
+
+
+class TestPythonScripts(unittest.TestCase):
+    """Test accessing string classes in Python Scripts.
+
+    Especially the Formatter class could be used by an attacker.
+    """
+
+    def test_script_formatter(self):
+        src = """
+from string import Formatter
+return "It worked!"
+"""
+        script = makerequest(PythonScript("formatterscript"))
+        script._filepath = "formatterscript"
+        script.write(src)
+        self.assertRaises(Unauthorized, script)
+
+    def test_script_template(self):
+        src = """
+from string import Template
+return "It worked!"
+"""
+        script = makerequest(PythonScript("templatescript"))
+        script._filepath = "templategetfieldscript"
+        script.write(src)
+        self.assertRaises(Unauthorized, script)


### PR DESCRIPTION
This takes over the [`AccessControl` fix](https://github.com/zopefoundation/AccessControl/security/advisories/GHSA-qcx9-j53g-ccgf) for good measure.